### PR TITLE
Activate the menu.

### DIFF
--- a/source/scenes/ExampleScene.lua
+++ b/source/scenes/ExampleScene.lua
@@ -36,6 +36,8 @@ function ExampleScene:init()
 		end
 	)
 
+	menu:activate()
+
 	local crankTick = 0
 
 	ExampleScene.inputHandler = {

--- a/source/scenes/ExampleScene2.lua
+++ b/source/scenes/ExampleScene2.lua
@@ -35,6 +35,8 @@ function ExampleScene2:init()
 		end
 	)
 
+	menu:activate()
+
 	local crankTick = 0
 
 	ExampleScene2.inputHandler = {


### PR DESCRIPTION
If you immediately tap 'a' on the first menu item, the game will crash with:

```
01:01:06: update failed: libraries/noble/modules/Noble.Menu.lua:353: attempt to call a nil value (field '?')
stack traceback:
	libraries/noble/modules/Noble.Menu.lua:353: in method 'click'
	scenes/ExampleScene.lua:59: in function <scenes/ExampleScene.lua:58>
01:01:06: Update failed, simulator paused.
```

According to the documentation, a menu needs to get activated first. Doing so prevents the crash.